### PR TITLE
Improve cpptoml

### DIFF
--- a/recipes/cpptoml/all/conandata.yml
+++ b/recipes/cpptoml/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "0.1.1":
     url: "https://github.com/skystrife/cpptoml/archive/refs/tags/v0.1.1.tar.gz"
     sha256: "23AF72468CFD4040984D46A0DD2A609538579C78DDC429D6B8FD7A10A6E24403"
-  "0.1.0":
-    url: "https://github.com/skystrife/cpptoml/archive/refs/tags/v0.1.0.tar.gz"
-    sha256: "11B1C07132D23E85071CEF3D0FE9BC605DE731FCD1B1C3F3D43ED09A6FD7A850"

--- a/recipes/cpptoml/all/conanfile.py
+++ b/recipes/cpptoml/all/conanfile.py
@@ -1,79 +1,28 @@
-from conans import ConanFile, tools, CMake
+from conans import ConanFile, tools
 import os
-import glob
 
 
 class CppTomlConan(ConanFile):
     name = "cpptoml"
     description = "cpptoml is a header-only library for parsing TOML "
-    topics = ("conan", "toml", "cpptoml")
-    license = " MIT License "
+    topics = ("toml", "header-only", "configuration")
+    license = "MIT"
     homepage = "https://github.com/skystrife/cpptoml"
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "arch", "compiler", "build_type"
-    options = {
-        "build_examples": [True, False]
-    }
-    default_options = {
-        "build_examples": False
-    }
-    generators = "cmake"
     no_copy_source = True
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob(self.name + "-*/")[0]
-        cmake_file = "{0}/CMakeLists.txt"\
-                     .format(extracted_dir)
-        search_pattern = "list(APPEND CMAKE_MODULE_PATH "\
-                         "${CMAKE_CURRENT_SOURCE_DIR}"\
-                         "/deps/meta-cmake)"
-        tools.replace_in_file(
-            cmake_file,
-            search_pattern,
-            ""
-        )
-        os.rename(extracted_dir, self._source_subfolder)
-
-    def build(self):
-        cmake = CMake(self)
-        cmake.definitions["CPPTOML_BUILD_EXAMPLES"] = \
-            self.options.build_examples
-
-        cmake.configure(
-            build_folder=self._build_subfolder,
-            source_folder=self._source_subfolder
-        )
-
-        cmake.build()
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True,
+                  destination=self._source_subfolder)
 
     def package(self):
-        include_folder = os.path.join(
-            self._source_subfolder,
-            "include"
-        )
-        self.copy(
-            pattern="LICENSE",
-            dst="licenses",
-            src=self._source_subfolder
-        )
-        self.copy(
-            pattern="*.h",
-            dst="include",
-            src=include_folder
-        )
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="*.h", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_id(self):
         self.info.header_only()
-
-    def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "cpptoml"
-        self.cpp_info.names["cmake_find_package_multi"] = "cpptoml"

--- a/recipes/cpptoml/all/test_package/CMakeLists.txt
+++ b/recipes/cpptoml/all/test_package/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O3")
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(cpptoml CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} cpptoml::cpptoml)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/cpptoml/all/test_package/conanfile.py
+++ b/recipes/cpptoml/all/test_package/conanfile.py
@@ -1,12 +1,9 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake, tools
 import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -14,18 +11,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        is_at_least_cpp11 = None
-        try: 
-            tools.check_min_cppstd(self, "11")
-            is_at_least_cpp11 = True
-        except Exception as error :
-            is_at_least_cpp11 = False
-        bin_path = os.path.join("bin", "test_package")
-        if self.settings.os == "Windows" and is_at_least_cpp11:
-            self.run(bin_path)
-        elif self.settings.os == "Macos" and is_at_least_cpp11:
-            self.run("DYLD_LIBRARY_PATH=%s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path))
-        elif is_at_least_cpp11:
-            self.run("LD_LIBRARY_PATH=%s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path))
-        else:
-            pass 
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/5428

Some points should be observed:

- Add only the latest version
- Use SPDX short license name
- This header-only project is too simple, a simple self.copy is much faster than all cmake engine
- Do not include examples or tests. The CCI is focused on packaging only
- By default, self.cpp_info.names, used self.name.
- Don't need to pass LD_LIBRARY_PATH or similar when using run_environment=True
- Don't use compiler flags, they are not portable. Use cmake properties instead
- CONAN_LIBS is useless for header-only, as it doesn't import any pre-built library.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
